### PR TITLE
Add some research notes about tail of DataMashup file

### DIFF
--- a/converters.py
+++ b/converters.py
@@ -190,7 +190,14 @@ class DataMashupConverter(Converter):
         - 4 null bytes
         - 4 bytes representing little-endian int for length of next xml
         - xml of this length
-        - not sure what the remainder is ...
+        - the four bytes 16 00 00 00
+        - a zip End (!) Of Central Directory record (indicated by the bytes 50 4b 05 06)
+          https://en.wikipedia.org/wiki/Zip_(file_format)#End_of_central_directory_record_(EOCD)
+          which is a bit surprising in this location, since there's no associated start of the zip file.
+          After some experiments, Power BI will not work if everything after 16 00 00 00 is omitted,
+          and also not if everything after 50 4b 05 06 is omitted, claiming the file has been corrupted.
+          If the tail of the file is replaced with that of a different .pbix file, there are no noticeable
+          errors in opening the modified .pbix file.
     """
 
     CONVERTERS = {

--- a/converters.py
+++ b/converters.py
@@ -198,6 +198,11 @@ class DataMashupConverter(Converter):
           and also not if everything after 50 4b 05 06 is omitted, claiming the file has been corrupted.
           If the tail of the file is replaced with that of a different .pbix file, there are no noticeable
           errors in opening the modified .pbix file.
+        - Some bytes further along in this file, I found the sequence 
+          01 00 00 00 D0 8C 9D DF 01 15 D1 11 8C 7A 00 C0 4F C2 97 EB 01 00 00 00 to be matching across
+          several different .pbix files. Even longer matches can be found across revisions of the
+          same .pbix file. Maybe this is metadata about the version of Power BI that was used, and other
+          metadata, since it seems harmless to transplant everything after the previously mentioned 16 00 00 00.
     """
 
     CONVERTERS = {


### PR DESCRIPTION
I'm also looking into creating Power BI version control tooling, so this repository is very helpful!

I noticed the tail of the ``DataMashup`` file has the bytes for the zip EOCD record (``50 4B 05 06``). That's strange, since there's no *opening* ``50 4B 03 04`` magic bytes for this zip file. Since it might be worth documenting for people who want to continue working on this, I updated the docstring of the function with some findings.